### PR TITLE
Add explicit returns in organo finder

### DIFF
--- a/app/utils/organo_finder.py
+++ b/app/utils/organo_finder.py
@@ -54,7 +54,7 @@ def encontrar_codigo_convocante(
 
         if close_session:
             session.close()
-
+        return result[0]
 
     # Fallback para órganos locales: Administracion = municipio,
     # Departamento = ayuntamiento, sin nivel2 en el CSV.
@@ -73,5 +73,7 @@ def encontrar_codigo_convocante(
 
     if close_session:
         session.close()
+
+    return None
 
       


### PR DESCRIPTION
## Summary
- return the first match when `result` exists
- ensure `encontrar_codigo_convocante` ends with `return None`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=app pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea8d78cb48323a2f1ea3739947334