### PR TITLE
Update session usage in convocante test script

### DIFF
--- a/app/utils/organo_finder.py
+++ b/app/utils/organo_finder.py
@@ -108,6 +108,7 @@ def encontrar_codigo_convocante(
                 if close_session:
                     session.close()
 
+                return cand.id
 
     if close_session:
         session.close()


### PR DESCRIPTION
## Summary
- ensure `procesar_archivo` manages its own database session
- simplify main to call `procesar_archivo` directly
- fix return statement when matching local organs

## Testing
- `PYTHONPATH=app python -m app.scripts.test_asignacion_convocante 2018 --selftest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684f0366182c83238f47c51ba86d471f