### PR TITLE
Fix download directory in convocatoria script

### DIFF
--- a/app/scripts/descargar_convocatorias.py
+++ b/app/scripts/descargar_convocatorias.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 URL_BASE = "https://www.infosubvenciones.es/bdnstrans/api"
 RUTA_LOGS = Path("logs")
-RUTA_DESCARGAS = Path("csv/convocatorias")
+RUTA_DESCARGAS = Path(__file__).resolve().parents[1] / "csv" / "convocatorias"
 RUTA_LOGS.mkdir(parents=True, exist_ok=True)
 RUTA_DESCARGAS.mkdir(parents=True, exist_ok=True)
 PRIMER_EJERCICIO = 2008


### PR DESCRIPTION
## Summary
- make convocatoria CSV path relative to `descargar_convocatorias.py`
- keep automatic directory creation

## Testing
- `python -m py_compile app/scripts/descargar_convocatorias.py`

------
https://chatgpt.com/codex/tasks/task_e_6850902db55c83239a7cf2d8dab293fe